### PR TITLE
Fix service worker caching and log timestamps

### DIFF
--- a/index.html
+++ b/index.html
@@ -141,7 +141,7 @@
     // Logs the calculation to localStorage
     function saveLog(currentBG, mealCarbs, totalBolus) {
       const logData = JSON.parse(localStorage.getItem("logData")) || [];
-      const timestamp = new Date().toLocaleString();
+      const timestamp = new Date().toISOString();
       logData.push({ timestamp, currentBG, mealCarbs, totalBolus });
       localStorage.setItem("logData", JSON.stringify(logData));
     }

--- a/log_graph_page.html
+++ b/log_graph_page.html
@@ -99,8 +99,9 @@
 
         logData.forEach(entry => {
             const row = document.createElement("tr");
+            const ts = new Date(entry.timestamp).toLocaleString();
             row.innerHTML = `
-                <td>${entry.timestamp}</td>
+                <td>${ts}</td>
                 <td>${entry.currentBG}</td>
                 <td>${entry.mealCarbs}</td>
                 <td>${entry.totalBolus}</td>

--- a/service-worker.js
+++ b/service-worker.js
@@ -4,9 +4,9 @@ self.addEventListener("install", (event) => {
       return cache.addAll([
         "./",
         "./index.html",
+        "./settings_page.html",
+        "./log_graph_page.html",
         "./manifest.json",
-        "./style.css", // Update with your CSS file path
-        "./script.js", // Update with your JS file path
         "./icon-192.png",
         "./icon-512.png"
       ]);


### PR DESCRIPTION
## Summary
- remove nonexistent files from service worker cache and add other HTML pages
- store timestamps in ISO format and convert to local string for display

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f59687cf88331a627a2b8cae2acf8